### PR TITLE
Update install.command

### DIFF
--- a/release/install/install.command
+++ b/release/install/install.command
@@ -1,7 +1,7 @@
 :; #!/bin/bash #
 :; #
 :; DL_INSTALL_ROOT="$(dirname "$(readlink -f "$0")")" #
-:; source "${DL_INSTALL_ROOT}/util/util.sh" #
+:; source "${DL_INSTALL_ROOT}/../../src/main/resources/mac/util/util.sh" #
 :; runDataLoader $@ run.mode=install #
 :; exit $? #
 


### PR DESCRIPTION
updated path to source (linux/mac)

Only change was on line 4. The path /util/util.sh doesn't exist from the current directory. 
The output after the change made (successful java version check, my environment doesn't have it yet):

`$ ./install.sh` 
Data Loader requires Java JRE @@MIN_JAVA_VERSION@@ or later. Checking if it is installed...
Did not find java command.

Java JRE @@MIN_JAVA_VERSION@@ or later is not installed or DATALOADER_JAVA_HOME environment variable is not set.
For example, download and install Zulu JRE @@MIN_JAVA_VERSION@@ or later from here:
    https://www.azul.com/downloads/
